### PR TITLE
Add RSA pubkey for OSDF issuer

### DIFF
--- a/ospool/oauth2/certs
+++ b/ospool/oauth2/certs
@@ -17,6 +17,14 @@
             "use": "sig",
             "x": "ZsvEqnMaAWT5bMcIt5lx3HajCw6xfhl387U95JPoc0g=",
             "y": "D3-Bf0RKzeBSwoNdzkzcvalE7VTCM-gVTlWgSqPQm28="
+        },
+        {
+            "alg": "RS256",
+            "e": "AQAB",
+            "kid": "5e49",
+            "kty": "RSA",
+            "n": "wq-65sR14rvKbwV2DK-HdRJlQQKUUPxIZ_vcCgu4dLGQWhNNWI6YSbqF8e2dLPf8E6Chp5Q3Ari69T8a8X1s5b35pIxe_Q1c7a2_q0U1Kvv1uxFo_6Fg3AqXhoRqB950sMg2sgvDzSCDTgX46Zbf-QSRPtdhcGuituGyyj5j1RQ4EJ1YKJo5Qof24ysMm5celTJxoitlOd_r8ma9mnz0pJqt98JL2DvrQs-Md7AzOAadA6LJXddV-c0lYC_ube_6YDRe6LXXVqqSShI5reeu2EoY8AAHcM9f6-bmNUMGw1kURUY5vsI3QmYeWkgUyDKi51SwhvZU0D_tvrdcQCG27w==",
+            "use": "sig"
         }
     ]
 }


### PR DESCRIPTION
We are working on creating a new issuer for the OSPool namespace in the OSDF.

Unfortunately, OA4MP doesn't support EC keys so we need to create a new RSA key solely for this purpose.