### PR TITLE
Post new public keys for use with the OSDF.

### DIFF
--- a/osdf/.well-known/openid-configuration
+++ b/osdf/.well-known/openid-configuration
@@ -1,0 +1,4 @@
+{  
+   "issuer":"https://osg-htc.org/osdf",
+   "jwks_uri":"https://osg-htc.org/osdf/public_signing_key.jwks"
+}

--- a/osdf/public_signing_key.jwks
+++ b/osdf/public_signing_key.jwks
@@ -1,0 +1,13 @@
+{
+    "keys": [
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "8256",
+            "kty": "EC",
+            "use": "sig",
+            "x": "17NhSZi0EBCoOGQksCRV_0LecriwggutdXpkl5ryyjU=",
+            "y": "jqwSHYD922tacQ-xkYvWpo95sfVsOKObw0CGQ1oAYJE="
+        }
+    ]
+}


### PR DESCRIPTION
Since issuers are cheap, create a new one for the OSDF service infrastructure (such as the caches, shovelers, collector, etc) instead of piggybacking on some other existing one.