### PR TITLE
Retire the signing key used by AP1 (INF-406)

### DIFF
--- a/ospool/oauth2/certs
+++ b/ospool/oauth2/certs
@@ -3,15 +3,6 @@
         {
             "alg": "ES256",
             "crv": "P-256",
-            "kid": "360e",
-            "kty": "EC",
-            "use": "sig",
-            "x": "IY4bFyz8qOVDnUSfwnWxgO9P0mkkxxzvJhP0ENz9xrQ=",
-            "y": "PJbxEFNvRVzmlV71RBLHAUHShF0D1GkEOQv4bIOW2zM="
-        },
-        {
-            "alg": "ES256",
-            "crv": "P-256",
             "kid": "b9ee",
             "kty": "EC",
             "use": "sig",


### PR DESCRIPTION
We used the same key across AP7 (OSPool) and AP1 (PATh Facility) to ease the transition for users from the OSG OSDF namespace to the PATh Facility namespace. That grace period is now over.