### PR TITLE
Add Pelican auto-discovery metadata

### DIFF
--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -1,0 +1,6 @@
+{
+  "director_endpoint": "https://director.osg-htc.org",
+  "namespace_registration_endpoint": "https://osdf-namespace.osgdev.chtc.io",
+  "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks",
+  "collector_endpoint": "condor://osdf-collector.osg-htc.org"
+}


### PR DESCRIPTION
The Pelican auto-discovery feature allows one to discover relevant endpoints for a Pelican federation from a fixed central URL.  This commit implements auto-discovery for the OSDF.