### PR TITLE
Update NSF grant #'s in acknowledgement

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -25,7 +25,7 @@
     <div class="container-xxl">
         <div class="row py-5">
             <div class="col text-center">
-                This work is supported by <a href="https://www.nsf.gov/div/index.jsp?div=OAC">NSF</a> under Grant Nos. 2030508, 1836650, and 1148698. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.. <br />
+                This work is supported by <a href="https://www.nsf.gov/div/index.jsp?div=OAC">NSF</a> under Grant Nos. 2030508 and 1836650. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation. <br />
             </div>
         </div>
     </div>


### PR DESCRIPTION
The acknowledgement in the footer is a bit dated, including a grant # that ended 2 years ago.

Since we don't acknowledge all of our historical funding in the footer, we should keep things in the present tense.