### PR TITLE
Temporarily point federation discovery at dev instances

### DIFF
--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -1,6 +1,6 @@
 {
-  "director_endpoint": "https://director.osg-htc.org",
-  "namespace_registration_endpoint": "https://osdf-namespace.osgdev.chtc.io/cli-namespaces",
+  "director_endpoint": "https://director-caches.osgdev.chtc.io",
+  "namespace_registration_endpoint": "https://registry.osgdev.chtc.io",
   "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks",
   "collector_endpoint": "condor://osdf-collector.osg-htc.org"
 }


### PR DESCRIPTION
There currently isn't a production instance of an osdf registry or director set up. To keep things working temporarily, this points at the dev instances (which should be working). Anyone who registers an origin using the new CLI might have to re-register when we point this someplace new, but that's a pretty easy thing to do at this point.