### PR TITLE
Update OSDF auto-discovery metadata

### DIFF
--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -1,6 +1,5 @@
 {
-  "director_endpoint": "https://director-caches.osgdev.chtc.io",
-  "namespace_registration_endpoint": "https://registry.osgdev.chtc.io",
-  "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks",
-  "collector_endpoint": "condor://osdf-collector.osg-htc.org"
+  "director_endpoint": "https://director-caches.osg-htc.org",
+  "namespace_registration_endpoint": "https://registry.osg-htc.org",
+  "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks"
 }


### PR DESCRIPTION
This points OSDF to the new osg-htc.org domains for the director and registry, and gets rid of the collector endpoint (which we haven't used in a long time).