### PR TITLE
Add openid and pelican configuration for the ITB OSDF federation

### DIFF
--- a/osdf/itb/.well-known/openid-configuration
+++ b/osdf/itb/.well-known/openid-configuration
@@ -1,0 +1,4 @@
+{  
+   "issuer":"https://osg-htc.org/osdf/itb",
+   "jwks_uri":"https://osg-htc.org/osdf/itb/public_signing_key.jwks"
+}

--- a/osdf/itb/.well-known/pelican-configuration
+++ b/osdf/itb/.well-known/pelican-configuration
@@ -1,0 +1,5 @@
+{
+  "director_endpoint": "https://itb-osdf-director-caches.osgdev.chtc.io",
+  "namespace_registration_endpoint": "https://itb-registry.osgdev.chtc.io",
+  "jwks_uri": "https://osg-htc.org/osdf/itb/public_signing_key.jwks"
+}

--- a/osdf/itb/.well-known/pelican-configuration
+++ b/osdf/itb/.well-known/pelican-configuration
@@ -1,5 +1,5 @@
 {
   "director_endpoint": "https://itb-osdf-director-caches.osgdev.chtc.io",
-  "namespace_registration_endpoint": "https://itb-registry.osgdev.chtc.io",
+  "namespace_registration_endpoint": "https://registry.osgdev.chtc.io",
   "jwks_uri": "https://osg-htc.org/osdf/itb/public_signing_key.jwks"
 }

--- a/osdf/itb/public_signing_key.jwks
+++ b/osdf/itb/public_signing_key.jwks
@@ -1,0 +1,20 @@
+{
+    "keys": [
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "8256",
+            "kty": "EC",
+            "use": "sig",
+            "x": "17NhSZi0EBCoOGQksCRV_0LecriwggutdXpkl5ryyjU=",
+            "y": "jqwSHYD922tacQ-xkYvWpo95sfVsOKObw0CGQ1oAYJE="
+        },
+        {
+            "n": "AOiqLjBO5LoWizi0orGOHnhW4S4wjP0fCOTiGcRX2EKAzK2juH0TptlBCi-s8h2kn-0w04DspLZn_tuKVAhMkh2HsG-tlbRn3_z_C_QshInPkXpIaTllUBlxCsrzD302_Ll0vYnmA5w3fD3ZBw6WjFTYYURoa2H4fuiunuAbla4IS2xb8eL8V00Sy1yIbz5xE5a5W6RowmadP54_CmdxCxKzU-_SrZQbNm2NLGih9PBuDxcdXU6gp4Ct0ZLoOMnL7IWwtKeVDZJO-dSwuSHtrxCzQMOQuvZfXcu6zhvaZqvreoRa7gO2GdjBFTXJ16L8B2frwzbWeVvmRNQw0FV9qbE",
+            "e": "AQAB",
+            "alg": "RS256",
+            "kid": "xrdshoveler",
+            "kty": "RSA"
+        }
+    ]
+}


### PR DESCRIPTION
The signing key is a copy of the production OSDF signing key for now.