### PR TITLE
Update osdf registry to osdf-registry.osg-htc.org

### DIFF
--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -1,5 +1,5 @@
 {
   "director_endpoint": "https://osdf-director.osg-htc.org",
-  "namespace_registration_endpoint": "https://registry.osg-htc.org",
+  "namespace_registration_endpoint": "https://osdf-registry.osg-htc.org",
   "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks"
 }


### PR DESCRIPTION
For updating the pelican config once the CNAME for the production registry is changed to the "osdf-registry.<domain>" format.