### PR TITLE
Fix OSDF ITB well-known pelican director_endpoint

### DIFF
--- a/osdf/itb/.well-known/pelican-configuration
+++ b/osdf/itb/.well-known/pelican-configuration
@@ -1,5 +1,5 @@
 {
-  "director_endpoint": "https://itb-osdf-director.osgdev.chtc.io",
+  "director_endpoint": "https://itb-osdf-director-caches.osgdev.chtc.io",
   "namespace_registration_endpoint": "https://itb-osdf-registry.osgdev.chtc.io",
   "jwks_uri": "https://osg-htc.org/osdf/itb/public_signing_key.jwks"
 }


### PR DESCRIPTION
I believe the previous change from itb-osdf-director-caches to itb-osdf-director was incorrect, the ITB director's hostname is itb-osdf-director-caches.osgdev.chtc.io

Undo PR #197