### PR TITLE
Update ITB pelican-configuration

### DIFF
--- a/osdf/itb/.well-known/pelican-configuration
+++ b/osdf/itb/.well-known/pelican-configuration
@@ -1,5 +1,5 @@
 {
-  "director_endpoint": "https://itb-osdf-director-caches.osgdev.chtc.io",
+  "director_endpoint": "https://itb-osdf-director.osgdev.chtc.io",
   "namespace_registration_endpoint": "https://itb-osdf-registry.osgdev.chtc.io",
   "jwks_uri": "https://osg-htc.org/osdf/itb/public_signing_key.jwks"
 }


### PR DESCRIPTION
Change ITB director_endpoint for the hostname change from itb-osdf-director-caches to itb-osdf-director, for the cache-response hostname.

@matyasselmeci Sorry Mat, looks like we're changing the ITB director's cache-reponse hostname to be more inline with the production director, right after we changed this back...