### PR TITLE
Add public key for ap42.uw.osg-htc.org

### DIFF
--- a/ospool/oauth2/certs
+++ b/ospool/oauth2/certs
@@ -10,6 +10,15 @@
             "y": "D3-Bf0RKzeBSwoNdzkzcvalE7VTCM-gVTlWgSqPQm28="
         },
         {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "0889",
+            "kty": "EC",
+            "use": "sig",
+            "x": "3_cLC0JcJX5W1E5zI5Hde2Gt6I6jGU0SnbBJbAFx0wo=",
+            "y": "0YlUfPgcWMljt0gKspjxhAkijIAJ7fTmTQkxFGVswL0="
+        },
+        {
             "alg": "RS256",
             "e": "AQAB",
             "kid": "5e49",


### PR DESCRIPTION
Otherwise known as ospool-ap42.chtc.wisc.edu; done in support of INF-1709: Provision dedicated IGWN OSPool AP https://opensciencegrid.atlassian.net/browse/INF-1709

Done with instructions from the CHTC Wiki [here](https://wiki.chtc.wisc.edu/wiki/Create_SciToken_Key_Pair_for_Credmon#OS_Pool).