### PR TITLE
Add OSDF-Director public signing key

### DIFF
--- a/osdf/public_signing_key.jwks
+++ b/osdf/public_signing_key.jwks
@@ -15,6 +15,14 @@
             "alg": "RS256",
             "kid": "xrdshoveler",
             "kty": "RSA"
+        },
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "sOgGIwIMg2CKR429hf2dNe8dBof0WvCqWHR1QKSoQ5U",
+            "kty": "EC",
+            "x": "VQkzkZVAmyrmu8fYKjoevEmlUZ45kWS0SfsIrMfpbQ4",
+            "y": "8FmvtdMrUwF8LZ_I4V1WgU0_b8WNXAkCFiCgeP3m_mU"
         }
     ]
 }


### PR DESCRIPTION
Add OSDF-Director's public signing key to the list of public signing keys at the OSDF metadata discoveryURL.