### PR TITLE
Update igwn-cit.yaml

### DIFF
--- a/_data/osdf_namespace_metadata/igwn-cit.yaml
+++ b/_data/osdf_namespace_metadata/igwn-cit.yaml
@@ -1,17 +1,21 @@
 description: |
+  User-managed data by members of the [LIGO Scientific Collaboration](www.ligo.org), the
+  [Virgo Collaboration](https://www.virgo-gw.eu/), and the [KAGRA Collaboration](https://gwcenter.icrr.u-tokyo.ac.jp/en/organization).
+  These data are created and used within individual users' workflows as they analyze gravitational-wave data in order
+  to detect black hole collisions and other cosmic phenomena. This origin is hosted at Caltech.
 
-organization: # Name of the organization
-dataVisibility: # public, or private
-size: # In bytes so I can parse how I want
+  This data is not yet public.
+organization: California Institute of Technology
+dataVisibility: private
+size: 31537610933565
+objectCount: 469323
 bytesXferd: # In bytes so I can parse how I want
-url: # Organization URL
-fieldOfScience: # Top level Field of Science pulled from here https://nces.ed.gov/ipeds/cipcode/browse.aspx?y=55
-numberOfDatasets: # Number of datasets in the namespace
+url: https://www.ligo.caltech.edu/
+fieldOfScience: Astronomy and Astrophysics
+numberOfDatasets: 1581 # This is how many users currently have directories. Should do the same as whatever you decide for ospool-apN
 rank: 0 # Rank of the namespace, 0 will have the lowest priority
 inProgress: false # Whether or not the namespace is in progress
 display: true # Whether or not to display this namespace
 name: # Human readable name of the namespace
 namespace: 
   - "/igwn/cit"
-thirtyDayReads: 641939268951660
-oneYearReads: 45946311946152008


### PR DESCRIPTION
Initial information for staging origin. Similar for LIGO/Virgo/KAGRA users to the ospool-AP<n> origins, so should probably be compared to those when they're populated (for instance, how many datasets)