### PR TITLE
Fix size and objectCount for /gwdata

### DIFF
--- a/_data/osdf_namespace_metadata/gwdata.yaml
+++ b/_data/osdf_namespace_metadata/gwdata.yaml
@@ -9,8 +9,8 @@ description: |
   accompany publications.
 organization: California Institute of Technology
 dataVisibility: public
-size: 341886627771
-objectCount: 1393
+size: 77032444311984
+objectCount: 1290210
 bytesXferd: # In bytes so I can parse how I want
 url: https://gwosc.org/
 fieldOfScience: Astronomy and Astrophysics


### PR DESCRIPTION
The previous numbers came from duc, which apparently doesn't follow symlinks, which this namespace for some reason has a lot of.