### PR TITLE
Make navbar dropdown menus mutually exclusive

### DIFF
--- a/assets/js/all.js
+++ b/assets/js/all.js
@@ -3,12 +3,22 @@
  */
 
 document.querySelectorAll('.dropdown-menu a').forEach(function(element) {
-	let nextEl = element.nextElementSibling;
-	if(nextEl && nextEl.classList.contains('dropdown-submenu')) {
+	const siblingSubmenu = element.nextElementSibling;
+	if(siblingSubmenu && siblingSubmenu.classList.contains('dropdown-submenu')) {
 		element.addEventListener('click', function (e) {
 			// prevent opening link if link needs to open dropdown
 			e.preventDefault();
 			e.stopPropagation();
+
+			// Close any other open submenus
+			const openSubmenus = document.querySelectorAll('a.dropdown-item.dropdown-toggle');
+			openSubmenus.forEach((submenu) => {
+				if (submenu !== element) {
+					submenu.classList.remove('show');
+					submenu.nextElementSibling.classList.remove('show'); // Hide the submenu
+					submenu.ariaExpanded = 'false';
+				}
+			});
 		});
 	}
 })


### PR DESCRIPTION
Makes the OSPool/OSDF submenu options in the navbar mutually exclusive (closes the other when clicked).

See #395