### PR TITLE
OPS-494: tell OSDF services to advertise to multiple directors

### DIFF
--- a/.well-known/openid-configuration
+++ b/.well-known/openid-configuration
@@ -1,1 +1,1 @@
-{"issuer":"https://osg-htc.org","jwks_uri":"https://osdf-director.osg-htc.org/.well-known/issuer.jwks"}
+{"issuer":"https://osg-htc.org","jwks_uri":"https://osg-htc.org/osdf/public_signing_key.jwks"}

--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -2,8 +2,8 @@
   "director_endpoint": "https://osdf-director.osg-htc.org",
   "namespace_registration_endpoint": "https://osdf-registry.osg-htc.org",
   "director_advertise_endpoints": [
-    "https://osdf-director.osg-htc.org",
-    "https://osdf-director-2.osg-htc.org"
+    "https://osdf-director.osg.chtc.io",
+    "https://osdf-director.osdf-prod.chtc.io"
   ],
   "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks"
 }

--- a/.well-known/pelican-configuration
+++ b/.well-known/pelican-configuration
@@ -1,5 +1,9 @@
 {
   "director_endpoint": "https://osdf-director.osg-htc.org",
   "namespace_registration_endpoint": "https://osdf-registry.osg-htc.org",
+  "director_advertise_endpoints": [
+    "https://osdf-director.osg-htc.org",
+    "https://osdf-director-2.osg-htc.org"
+  ],
   "jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks"
 }


### PR DESCRIPTION
We probably need to add a CNAME / other configs to the NRP director so that it can be contacted at osdf-director-2.osg-htc.org. Matt W has verified that we can use osg-htc.org certs in NRP